### PR TITLE
로그인 및 회원가입 사가 구현 마무리 

### DIFF
--- a/trace/@types/interface.ts
+++ b/trace/@types/interface.ts
@@ -50,4 +50,5 @@ export interface SignUpType {
     isMember: boolean;
     isDouble: boolean;
     error: any;
+    verifyNum: string;
 }

--- a/trace/@types/interface.ts
+++ b/trace/@types/interface.ts
@@ -59,5 +59,5 @@ export interface LoginType {
     password: string;
     isloading: boolean;
     error: any;
-    isSuccess: boolean;
+    isLoginSuccess: boolean;
 }

--- a/trace/@types/interface.ts
+++ b/trace/@types/interface.ts
@@ -52,3 +52,12 @@ export interface SignUpType {
     error: any;
     verifyNum: string;
 }
+
+// 로그인 타입
+export interface LoginType {
+    userId: string;
+    password: string;
+    isloading: boolean;
+    error: any;
+    isSuccess: boolean;
+}

--- a/trace/components/layouts/Header.tsx
+++ b/trace/components/layouts/Header.tsx
@@ -107,6 +107,12 @@ const Header = () => {
         (state: RootState) => state.ModalPage.isOpen
     );
 
+    // 로그인 여부 판단.
+
+    const isLogin = useSelector(
+        (state: RootState) => state.login.isLoginSuccess
+    );
+
     const showModal = () => {
         dispatch(openModal());
     };
@@ -144,9 +150,15 @@ const Header = () => {
                 </MenuBtn>
                 <MenuBtn href="/community">커뮤니티</MenuBtn>
                 <MenuBtn href="/write">글쓰기</MenuBtn>
-                <Button type="primary" onClick={showModal}>
-                    로그인/회원가입
-                </Button>
+
+                {!isLogin ? (
+                    <Button type="primary">Mypage</Button>
+                ) : (
+                    <Button type="primary" onClick={showModal}>
+                        로그인/회원가입
+                    </Button>
+                )}
+
                 <LoginForm
                     visible={isModalVisible}
                     onCancel={handleCancel}

--- a/trace/components/layouts/Login.tsx
+++ b/trace/components/layouts/Login.tsx
@@ -12,7 +12,7 @@ import SignUp4 from "./SignUp4";
 import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "redux";
 import { goPage2 } from "Redux/ModalPage";
-
+import { loginReq } from "Redux/login";
 export const Container = styled.div`
     background-image: url(${LoginBack});
     background-size: cover;
@@ -55,6 +55,24 @@ const Login = () => {
         dispatch(goPage2());
     };
 
+    const [userId, setId] = useState("");
+    const [password, setPassword] = useState("");
+    // 아이디 핸들러
+
+    const handleId = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setId(e.target.value);
+    };
+    // 비밀번호 핸들러
+
+    const handlePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setPassword(e.target.value);
+    };
+    // 로그인 요청
+
+    const goLogin = () => {
+        dispatch(loginReq({ userId, password }));
+    };
+
     return (
         <>
             {page1 && (
@@ -65,17 +83,22 @@ const Login = () => {
                             id="standard-basic"
                             label="아이디"
                             style={{ marginBottom: "10px" }}
+                            value={userId}
+                            onChange={handleId}
                         />
                         <TextField
                             id="standard-basic"
                             label="비밀번호"
                             type="password"
                             style={{ marginBottom: "50px" }}
+                            value={password}
+                            onChange={handlePassword}
                         />
                         <LoginButton
                             variant="contained"
                             color="primary"
                             size="large"
+                            onClick={goLogin}
                         >
                             로그인
                         </LoginButton>

--- a/trace/components/layouts/SignUp2.tsx
+++ b/trace/components/layouts/SignUp2.tsx
@@ -39,11 +39,11 @@ const SignUp2 = () => {
 
     /// 이름 핸들러
 
-    const handleName = (e: any) => {
+    const handleName = (e: React.ChangeEvent<HTMLInputElement>) => {
         setName(e.target.value);
     };
     // 폰 번호 핸들러
-    const handlePhone = (e: any) => {
+    const handlePhone = (e: React.ChangeEvent<HTMLInputElement>) => {
         setPhoneNum(e.target.value);
     };
 

--- a/trace/components/layouts/SignUp3.tsx
+++ b/trace/components/layouts/SignUp3.tsx
@@ -8,9 +8,15 @@ import { InputContainer, BtnContainer } from "./SignUp2";
 import TextField from "@material-ui/core/TextField";
 import { useDispatch } from "react-redux";
 import { goPage3, goPage5 } from "Redux/ModalPage";
+import { emailVerifyReq } from "Redux/SignUp";
 
+const VeriContainer = styled.div``;
+
+///////////////////////////////////////////////////////////////////////////////////////////////
 const SignUp3 = () => {
     const dispatch = useDispatch();
+
+    const [email, setEmail] = useState("");
 
     //다음 페이지
     const goNext = () => {
@@ -19,6 +25,18 @@ const SignUp3 = () => {
     //이전 페이지
     const goBack = () => {
         dispatch(goPage3());
+    };
+
+    // 이메일 텍스트 필드 핸들러
+
+    const handleEmail = (e: any) => {
+        setEmail(e.target.value);
+    };
+
+    // 인증번호 전송하면 디스패치
+
+    const goVerifyEmail = () => {
+        dispatch(emailVerifyReq(email));
     };
 
     return (
@@ -30,13 +48,24 @@ const SignUp3 = () => {
                     id="standard-basic"
                     label="킹고 이메일"
                     style={{ marginBottom: "10px" }}
+                    value={email}
+                    onChange={handleEmail}
                 />
-                <TextField
-                    id="standard-basic"
-                    label="인증번호"
-                    style={{ marginBottom: "50px" }}
-                />
-                <Button>인증번호 전송</Button>
+                <VeriContainer>
+                    <TextField
+                        id="standard-basic"
+                        label="인증번호"
+                        style={{ marginBottom: "50px" }}
+                    />
+                    <Button
+                        variant="outlined"
+                        style={{ marginLeft: "25px", marginTop: "10px" }}
+                    >
+                        확인
+                    </Button>
+                </VeriContainer>
+
+                <Button onClick={goVerifyEmail}>인증번호 전송</Button>
             </InputContainer>
             <BtnContainer>
                 <Button style={{ fontSize: "24px" }} onClick={goBack}>

--- a/trace/components/layouts/SignUp3.tsx
+++ b/trace/components/layouts/SignUp3.tsx
@@ -29,7 +29,7 @@ const SignUp3 = () => {
 
     // 이메일 텍스트 필드 핸들러
 
-    const handleEmail = (e: any) => {
+    const handleEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
         setEmail(e.target.value);
     };
 

--- a/trace/components/layouts/SignUp4.tsx
+++ b/trace/components/layouts/SignUp4.tsx
@@ -29,18 +29,18 @@ const SignUp4 = () => {
     const [isSame, setIsSame] = useState(false);
 
     // 아이디 핸들러
-    const handleId = (e: any) => {
+    const handleId = (e: React.ChangeEvent<HTMLInputElement>) => {
         setId(e.target.value);
     };
 
     // 비밀번호 핸들러
 
-    const handlePassword = (e: any) => {
+    const handlePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
         setPassword(e.target.value);
     };
 
     // 비밀번호 확인 핸들러
-    const handleConfirmPassword = (e: any) => {
+    const handleConfirmPassword = (e: React.ChangeEvent<HTMLInputElement>) => {
         setConfirmPassword(e.target.value);
     };
 

--- a/trace/components/layouts/SignUp4.tsx
+++ b/trace/components/layouts/SignUp4.tsx
@@ -1,19 +1,63 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { useDispatch } from "react-redux";
 import styled from "@emotion/styled";
 import MainLogo from "assets/images/MainLogo.png";
 import Button from "@material-ui/core/Button";
 import Id from "assets/images/Id.png";
 import { Container, LogoImg } from "./Login";
-import { InputContainer, BtnContainer } from "./SignUp2";
-import SignUp2 from "./SignUp2";
+import { InputContainer } from "./SignUp2";
 import TextField from "@material-ui/core/TextField";
+import { idDoubleCheckReq } from "Redux/SignUp";
 
 const IdContainer = styled.div`
     display: flex;
     align-content: center;
 `;
+///////////////////////////////////////////////////////////////////////////////////////////////////////
 
 const SignUp4 = () => {
+    const dispatch = useDispatch();
+
+    const [id, setId] = useState("");
+
+    const [password, setPassword] = useState("");
+
+    const [confirmPassword, setConfirmPassword] = useState("");
+
+    // 비밀번호와 비밀번호 확인 같은지 확인
+
+    const [isSame, setIsSame] = useState(false);
+
+    // 아이디 핸들러
+    const handleId = (e: any) => {
+        setId(e.target.value);
+    };
+
+    // 비밀번호 핸들러
+
+    const handlePassword = (e: any) => {
+        setPassword(e.target.value);
+    };
+
+    // 비밀번호 확인 핸들러
+    const handleConfirmPassword = (e: any) => {
+        setConfirmPassword(e.target.value);
+    };
+
+    // 아이디 중복 체크 요청
+
+    const goIdCheck = () => {
+        dispatch(idDoubleCheckReq(id));
+    };
+
+    useEffect(() => {
+        if (password === confirmPassword) {
+            setIsSame(true);
+        } else {
+            setIsSame(false);
+        }
+    }, [password, confirmPassword]);
+
     return (
         <Container>
             <LogoImg src={MainLogo}></LogoImg>
@@ -24,6 +68,8 @@ const SignUp4 = () => {
                         id="standard-basic"
                         label="아이디"
                         style={{ marginBottom: "10px" }}
+                        value={id}
+                        onChange={handleId}
                     />
                     <Button
                         variant="outlined"
@@ -33,6 +79,7 @@ const SignUp4 = () => {
                             marginTop: "15px",
                             marginLeft: "20px",
                         }}
+                        onClick={goIdCheck}
                     >
                         중복확인
                     </Button>
@@ -42,12 +89,18 @@ const SignUp4 = () => {
                     label="비밀번호"
                     style={{ marginBottom: "10px" }}
                     type="password"
+                    value={password}
+                    onChange={handlePassword}
                 />
                 <TextField
+                    error={isSame ? false : true}
                     id="standard-basic"
                     label="비밀번호 확인"
                     style={{ marginBottom: "50px" }}
                     type="password"
+                    value={confirmPassword}
+                    onChange={handleConfirmPassword}
+                    helperText={isSame ? null : "다시 확인해주세요"}
                 />
 
                 <Button variant="outlined">회원가입</Button>

--- a/trace/package.json
+++ b/trace/package.json
@@ -50,5 +50,6 @@
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
         "typescript": "^4.1.3"
-    }
+    },
+    "proxy": "http://jjaggutrace.com"
 }

--- a/trace/redux/SignUp.ts
+++ b/trace/redux/SignUp.ts
@@ -8,6 +8,7 @@ export const SignUpState: SignUpType = {
     isMember: false,
     isDouble: true,
     error: null,
+    verifyNum: "", /// 이메일 인증 번호
 };
 
 //유저 상태 리듀서
@@ -42,12 +43,12 @@ export const SignUp = createSlice({
             state.isloading = true;
         },
 
-        // 중복되면
+        // 아이디 중복되면
         idDoubleYes: (state) => {
             state.isloading = false;
             state.isDouble = true;
         },
-        // 중복 안되면
+        // 아이디 중복 안되면
         idDoubleNo: (state) => {
             state.isloading = false;
             state.isDouble = false;
@@ -57,6 +58,21 @@ export const SignUp = createSlice({
         idDoubleCheckFail: (state, { payload }) => {
             state.isloading = false;
             state.isDouble = true;
+            state.error = payload;
+        },
+
+        // 이메일 인증 요청
+        emailVerifyReq: (state, { payload }) => {
+            state.isloading = true;
+        },
+        // 이메일 인증 요청 성공시 검증 번호 저장.
+        emailVerifySuccess: (state, { payload }) => {
+            state.isloading = false;
+            state.verifyNum = payload;
+        },
+        // 이메일 인증 요청 실패
+        emailVerifyFail: (state, { payload }) => {
+            state.isloading = false;
             state.error = payload;
         },
     },
@@ -71,6 +87,9 @@ export const {
     idDoubleYes,
     idDoubleNo,
     idDoubleCheckFail,
+    emailVerifyReq,
+    emailVerifySuccess,
+    emailVerifyFail,
 } = SignUp.actions;
 
 export default SignUp.reducer;

--- a/trace/redux/index.ts
+++ b/trace/redux/index.ts
@@ -4,6 +4,7 @@ import review from "./review";
 import SignUp from "./SignUp";
 import user from "./user";
 import ModalPage from "./ModalPage";
+import login from "./login";
 
 const rootReducer = (state: any, action: any) => {
     switch (action.type) {
@@ -15,6 +16,7 @@ const rootReducer = (state: any, action: any) => {
                 SignUp,
                 user,
                 ModalPage,
+                login,
             });
             return combineReducer(state, action);
         }

--- a/trace/redux/login.ts
+++ b/trace/redux/login.ts
@@ -1,1 +1,38 @@
-// 로그인
+// 로그인 상태 관리
+
+import { createSlice } from "@reduxjs/toolkit";
+import { LoginType } from "../@types/interface";
+
+export const LoginState: LoginType = {
+    userId: "",
+    password: "",
+    isSuccess: false,
+    isloading: false,
+    error: null,
+};
+
+export const Login = createSlice({
+    name: "Login",
+    initialState: LoginState,
+    reducers: {
+        loginReq: (state, { payload }) => {
+            state.isloading = true;
+            state.userId = payload.userId;
+            state.password = payload.password;
+        },
+
+        loginSuccess: (state) => {
+            state.isloading = false;
+            state.isSuccess = true;
+        },
+
+        loginFail: (state, { payload }) => {
+            state.isloading = false;
+            state.error = payload;
+        },
+    },
+});
+
+export const { loginReq, loginSuccess, loginFail } = Login.actions;
+
+export default Login.reducer;

--- a/trace/redux/login.ts
+++ b/trace/redux/login.ts
@@ -6,7 +6,7 @@ import { LoginType } from "../@types/interface";
 export const LoginState: LoginType = {
     userId: "",
     password: "",
-    isSuccess: false,
+    isLoginSuccess: false,
     isloading: false,
     error: null,
 };
@@ -23,7 +23,7 @@ export const Login = createSlice({
 
         loginSuccess: (state) => {
             state.isloading = false;
-            state.isSuccess = true;
+            state.isLoginSuccess = true;
         },
 
         loginFail: (state, { payload }) => {

--- a/trace/sagas/LoginSaga.ts
+++ b/trace/sagas/LoginSaga.ts
@@ -1,12 +1,44 @@
 // 로그인/회원가입에 대한 사가.
-import { all, fork, takeLatest, put } from "redux-saga/effects";
+import { all, fork, takeLatest, put, call } from "redux-saga/effects";
+import { loginFail, loginReq, loginSuccess } from "Redux/login";
 
 import axios from "axios";
 
 // 로그인 사가
 
+const Domain: String = "http://jjaggutrace.com";
+
+// 로그인 요청(post)
+
+function LoginPost(userData: { userId: string; password: string }) {
+    return axios.post(`${Domain}/api/v1/members/login`, userData);
+}
+
+// 로그인 사가
+
+function* LoginSagaReq({ payload }: any) {
+    console.log("hi");
+    try {
+        const res = yield call(LoginPost, payload);
+        console.log(res);
+        if (res.success === "true") {
+            yield put(loginSuccess());
+        } else {
+        }
+    } catch (error) {
+        console.log(error);
+        yield put(loginFail(error));
+    }
+}
+
+// watch
+
+function* watchLoginSagaReq() {
+    yield takeLatest(loginReq, LoginSagaReq);
+}
+
 //////////////////////////////////////
 
 export default function* LoginSaga(): Generator {
-    yield all([fork()]);
+    yield all([fork(watchLoginSagaReq)]);
 }

--- a/trace/sagas/SignUpSaga.ts
+++ b/trace/sagas/SignUpSaga.ts
@@ -23,6 +23,7 @@ import {
 } from "Redux/user";
 import axios from "axios";
 
+// 도메인
 const Domain: String = "http://jjaggutrace.com";
 
 // 기존 회원 여부 체크 요청(get)

--- a/trace/sagas/SignUpSaga.ts
+++ b/trace/sagas/SignUpSaga.ts
@@ -9,6 +9,9 @@ import {
     idDoubleYes,
     idDoubleNo,
     idDoubleCheckFail,
+    emailVerifyReq,
+    emailVerifySuccess,
+    emailVerifyFail,
 } from "Redux/SignUp";
 import {
     preferenceWrite,
@@ -16,18 +19,26 @@ import {
     setId,
     setPassWord,
     setEmail,
+    user,
 } from "Redux/user";
 import axios from "axios";
 
-// 회원가입 사가
+const Domain: String = "http://jjaggutrace.com";
 
 // 기존 회원 여부 체크 요청(get)
 function memberCheckGet(userData: { name: string; phoneNum: string }) {
-    return axios.get("example_url");
+    return axios.get(
+        `${Domain}/api/v1/auth/registered?name=${userData.name}&phoneNum=${userData.phoneNum}`
+    );
 }
 // 아이디 중복 확인(get)
 function idDoubleGet(id: string) {
-    return axios.get(`/api/v1/members/verification?userId=${id}`);
+    return axios.get(`${Domain}/api/v1/auth/registered?userId=${id}`);
+}
+
+// 이메일 인증(get)
+function emailVerify(email: string) {
+    return axios.get(`${Domain}/api/v1/mail/verification?mail=${email}`);
 }
 
 // 기존 회원가입 여부 판단 사가
@@ -37,13 +48,13 @@ function* nameAndPhoneSaga({ payload }: any) {
         const res = yield call(memberCheckGet, payload);
         console.log(res);
         // 응답이 오면 그 응답에 맞게 필터링.
-        if (res) {
-            // 멤버가 아니면 유저 상태에 값 업데이트
-            yield put(isMemberNo());
-            yield put(setNameAndPhone(payload));
-        } else {
-            yield put(isMemberYes());
-        }
+        // if (res) {
+        //     // 멤버가 아니면 유저 상태에 값 업데이트
+        //     yield put(isMemberNo());
+        //     yield put(setNameAndPhone(payload));
+        // } else {
+        //     yield put(isMemberYes());
+        // }
     } catch (error) {
         console.log(error);
         yield put(isMemberCheckFail(error));
@@ -67,6 +78,20 @@ function* idDoubleCheckSaga({ payload }: any) {
     }
 }
 
+// 이메일 인증 사가
+
+function* emailCheckSaga({ payload }: any) {
+    try {
+        const {
+            data: { verificationKey },
+        } = yield call(emailVerify, payload);
+        yield put(emailVerifySuccess(verificationKey));
+    } catch (error) {
+        console.log(error);
+        yield emailVerifyFail(error);
+    }
+}
+
 // 기존 회원인지 아닌지 계속 watch
 function* watchsetNameAndPhoneSaga() {
     yield takeLatest(isMemberCheckReq, nameAndPhoneSaga);
@@ -76,8 +101,17 @@ function* watchIdDoubleCheckSaga() {
     yield takeLatest(idDoubleCheckReq, idDoubleCheckSaga);
 }
 
+// 이메일 리퀘스트 watch
+function* watchEmailCheckSaga() {
+    yield takeLatest(emailVerifyReq, emailCheckSaga);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 export default function* SignUpSaga(): Generator {
-    yield all([fork(watchsetNameAndPhoneSaga), fork(watchIdDoubleCheckSaga)]);
+    yield all([
+        fork(watchsetNameAndPhoneSaga),
+        fork(watchIdDoubleCheckSaga),
+        fork(watchEmailCheckSaga),
+    ]);
 }

--- a/trace/sagas/index.ts
+++ b/trace/sagas/index.ts
@@ -1,7 +1,9 @@
 import { all, fork } from "redux-saga/effects";
 import reviewSaga from "./reviewSaga";
 import SignUpSaga from "./SignUpSaga";
+import LoignSaga from "./LoginSaga";
+import LoginSaga from "./LoginSaga";
 
 export default function* rootSaga() {
-    yield all([fork(reviewSaga), fork(SignUpSaga)]);
+    yield all([fork(reviewSaga), fork(SignUpSaga), fork(LoginSaga)]);
 }


### PR DESCRIPTION
1. 로그인 사가를 구현했습니다. 
- Redux/login : 로그인 시 아이디와 비밀번호의 상태관리를 하는 리덕스
- Sagas/LoginSaga : 로그인 요청을 보내는 사가.

2. 그리고 각 모달창 별로 핸들러를 추가했습니다( 각종 api 요청에 필요한 정보들에 대한 것입니다.)

3. 로그인이 성공되면 로그인/회원가입 버튼이 마이페이지 버튼으로 렌더링 되게 추가했습니다.

4. 각 기능 및 코드별로 주석을 달아놨습니다. 혹시나 이해가 안되거나 의문점이 있다면 코멘트 달아주세요!